### PR TITLE
[fix/#91] 현황카드 도서명 제한, 독서 캘린더 api 통합

### DIFF
--- a/src/api/user/getCalendar.ts
+++ b/src/api/user/getCalendar.ts
@@ -1,15 +1,13 @@
 import api from "..";
 import { TCalendarRes } from "../../types/challenge";
 
-//챌린지 참가자의 날짜별 독서 기록 조회
+//특정 유저의 날짜별 독서 기록 조회
 export const getCalendar = async (
-  participantId: number,
+  userId: number,
   date: string
 ): Promise<TCalendarRes[] | undefined> => {
   try {
-    const response = await api.get(
-      `/api/v1/challenges/participants/${participantId}/calendar/${date}`
-    );
+    const response = await api.get(`/api/v1/users/${userId}/calendar/${date}`);
     return response.data;
   } catch (e) {
     console.log(e);

--- a/src/components/challenge/ChallengeCard.tsx
+++ b/src/components/challenge/ChallengeCard.tsx
@@ -84,7 +84,11 @@ const ChallengeCard = ({
                     />
                   </View>
                   <View style={styles.bookTextWrap}>
-                    <Text style={styles.bookText}>
+                    <Text
+                      style={styles.bookText}
+                      numberOfLines={2}
+                      ellipsizeMode="tail"
+                    >
                       {clickStatus.readingBookTitle}
                     </Text>
                     <Text

--- a/src/pages/challengePage/ChallengeDetailPage.tsx
+++ b/src/pages/challengePage/ChallengeDetailPage.tsx
@@ -196,7 +196,7 @@ export default function ChallengeDetailPage({
               handleStatus={() =>
                 navigation.navigate("StatusCardDetail", {
                   clickStatus: {
-                    participantId: clickStatus?.participantId,
+                    userId: clickStatus?.userId,
                     nickname: clickStatus?.nickname,
                   },
                   isCurrentUser: false,

--- a/src/pages/challengePage/StatusCardDetailPage.tsx
+++ b/src/pages/challengePage/StatusCardDetailPage.tsx
@@ -6,7 +6,7 @@ import { Calendar, DateData, LocaleConfig } from "react-native-calendars";
 import ArrowLeftIcon from "../../assets/images/challange/ArrowLeft.svg";
 import ArrowRightIcon from "../../assets/images/challange/ArrowRight.svg";
 import { Color, Font } from "../../styles/Theme";
-import { getCalendar } from "../../api/challenge/getCalendar";
+import { getCalendar } from "../../api/user/getCalendar";
 import { TCalendarRes } from "../../types/challenge";
 import { useFocusEffect } from "@react-navigation/native";
 import { getMyCalendar } from "../../api/userBook/getMyCalendar";
@@ -93,7 +93,7 @@ export default function StatusCardDetailPage({
   const fetchChallengeDetail = async () => {
     try {
       const response = await getCalendar(
-        clickStatus.participantId,
+        clickStatus.userId,
         `${selectedDate.year}-${selectedDate.month.toString().padStart(2, "0")}`
       );
       if (response) {

--- a/src/pages/myPage/FriendSearchResultPage.tsx
+++ b/src/pages/myPage/FriendSearchResultPage.tsx
@@ -80,8 +80,8 @@ const FriendSearchResultPage = ({
               onPress={() =>
                 navigation.navigate("StatusCardDetail", {
                   clickStatus: {
-                    participantId: userId,
-                    nickname: nickname,
+                    userId,
+                    nickname,
                   },
                   isCurrentUser: false,
                 })

--- a/src/types/challenge.ts
+++ b/src/types/challenge.ts
@@ -64,6 +64,7 @@ export type TChallengeDetailInformationRes = {
 };
 
 export type TChallengeDetailParticipantsRes = {
+  userId: number;
   participantId: number;
   nickname: string;
   participantImage: string;


### PR DESCRIPTION
## 🌏 Summary
<!-- 어떤 내용의 PR인가요? -->

> 현황카드 도서명 제한, 독서 캘린더 api 통합

## ✨ Work Detail
<!-- 작업 내용을 적어주세요 -->

### 챌린지 페이지
- [x] 현황카드 도서명 text 제한 2줄까지로 수정

### 독서 캘린더
- [x] 독서 캘린더 api 통합
